### PR TITLE
OpenCV support in Utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
         - title=utils/cpp
       before_install:
         - pip install --user cpp-coveralls
+      instal:
+        - apt-get install libopencv-dev
       script: bash bin/utils/cpp/test.sh
 
     - language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
         - title=poseidon/raspberryPI
       before_install:
         - pip install --user cpp-coveralls
+      install:
+        - sudo apt-get install -y libopencv-dev
       script: bash bin/poseidon/raspberryPI/test.sh
 
     - language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
         - title=utils/cpp
       before_install:
         - pip install --user cpp-coveralls
-      instal:
+      install:
         - apt-get install libopencv-dev
       script: bash bin/utils/cpp/test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       before_install:
         - pip install --user cpp-coveralls
       install:
-        - apt-get install libopencv-dev
+        - sudo apt-get install -y libopencv-dev
       script: bash bin/utils/cpp/test.sh
 
     - language: cpp

--- a/utils/cpp/CMakeLists.txt
+++ b/utils/cpp/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required (VERSION 2.8.12)
 set(PROJECT_NAME Utils)
 project (${PROJECT_NAME})
 
+find_package( OpenCV )
+
 option(tests "Build tests" OFF)
 option(coverage "Enable coverage output" OFF)
 
@@ -34,6 +36,15 @@ foreach(SOURCE_FILE ${SOURCE_FILES})
 endforeach()
 
 add_library(${PROJECT_NAME} ${SOURCE_FILES})
+
+message("======= OpenCV =======")
+if(${OpenCV_FOUND})
+  target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBS})
+  add_definitions(-DENABLE_OPEN_CV)
+  message(" - Found OpenCV")
+else()
+  message(" - Missing OpenCV, not going to build related code.")
+endif()
 
 if(${tests})
   include_directories(${SOURCE_DIR}/mock)

--- a/utils/cpp/src/Vision/OpenCV.spec.cpp
+++ b/utils/cpp/src/Vision/OpenCV.spec.cpp
@@ -3,7 +3,7 @@
 #include <opencv2/opencv.hpp>
 #include <catch.hpp>
 
-TEST_CASE("opencv", "[opencv]"){
+TEST_CASE("the project links to OpenCV", "[OpenCV_Include]"){
   cv::Mat image;
 }
 

--- a/utils/cpp/src/Vision/OpenCV.spec.cpp
+++ b/utils/cpp/src/Vision/OpenCV.spec.cpp
@@ -1,0 +1,10 @@
+#ifdef ENABLE_OPEN_CV
+
+#include <opencv2/opencv.hpp>
+#include <catch.hpp>
+
+TEST_CASE("opencv", "[opencv]"){
+  cv::Mat image;
+}
+
+#endif


### PR DESCRIPTION
OpenCV has been added to `utils/cpp` CMake config. The Raspberry PI also has access if all the OpenCV code is kept in `utils/cpp`. Satisfies issue #19.